### PR TITLE
docs(contributing): update getting started steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Other processes and specifications that are in use in this repository are:
 This repository requires that a supported version of [Node.js](https://nodejs.org) is installed.
 Check the `engines.node` value in `./package.json` for the minimum supported version.
 
-With that in place, fork the repository, clone it, and then run `npm i && npm run prepare` to install all dependencies.
+With that in place, fork the repository, clone it, and then run `npm i` to install all dependencies.
 
 ### Development workflow
 


### PR DESCRIPTION
Removed '&& npm run prepare' from installation instructions as `prepare` not used anywhere with the removal of Husky.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
